### PR TITLE
making the association thing work

### DIFF
--- a/db/migrations/20221230181256_create_organizations.cr
+++ b/db/migrations/20221230181256_create_organizations.cr
@@ -4,7 +4,7 @@ class CreateOrganizations::V20221230181256 < Avram::Migrator::Migration::V1
     create table_for(Organization) do
       primary_key id : Int64
       add_timestamps
-      add_belongs_to owner : User, on_delete: :cascade
+      add_belongs_to user : User, on_delete: :cascade
       add name : String
     end
   end

--- a/src/models/organization.cr
+++ b/src/models/organization.cr
@@ -1,6 +1,6 @@
 class Organization < BaseModel
   table do
     column name : String
-    belongs_to owner : User
+    belongs_to owner : User, foreign_key: :user_id
   end
 end

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -5,6 +5,7 @@ class User < BaseModel
   table do
     column email : String
     column encrypted_password : String
+    has_one organization : Organization
   end
 
   def emailable : Carbon::Address

--- a/src/operations/sign_up_user.cr
+++ b/src/operations/sign_up_user.cr
@@ -3,6 +3,8 @@ class SignUpUser < User::SaveOperation
   # Change password validations in src/operations/mixins/password_validations.cr
   include PasswordValidations
 
+  has_one organization : SaveOrganization
+
   permit_columns email
   attribute password : String
   attribute password_confirmation : String

--- a/src/pages/sign_ups/new_page.cr
+++ b/src/pages/sign_ups/new_page.cr
@@ -15,6 +15,7 @@ class SignUps::NewPage < AuthLayout
   end
 
   private def sign_up_fields(op)
+    mount Shared::Field, attribute: op.organization.name, label_text: "Org Name", &.text_input
     mount Shared::Field, attribute: op.email, label_text: "Email", &.email_input(autofocus: "true")
     mount Shared::Field, attribute: op.password, label_text: "Password", &.password_input
     mount Shared::Field, attribute: op.password_confirmation, label_text: "Confirm Password", &.password_input


### PR DESCRIPTION
I had to change the migration because the current implementation doesn't allow you to specify the foreign key on the operation.

This also doesn't work for a M2M way, but the idea would be very similar. Imagine the operation has a `has_many orgs : SaveAllTheOrgs`.... 